### PR TITLE
Removed call history limit (#125)

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/phone/fragments/RecentsFragment.kt
@@ -59,7 +59,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
     }
 
     override fun refreshItems(callback: (() -> Unit)?) {
-        val privateCursor = context?.getMyContactsCursor(false, true)
+        val privateCursor = context?.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
         val groupSubsequentCalls = context?.config?.groupSubsequentCalls ?: false
         RecentsHelper(context).getRecentCalls(groupSubsequentCalls, MIN_RECENTS_THRESHOLD, allRecentCalls) { recents ->
             ContactsHelper(context).getContacts(showOnlyContactsWithNumbers = true) { contacts ->
@@ -123,7 +123,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
     }
 
     private fun getMoreRecentCalls() {
-        val privateCursor = context?.getMyContactsCursor(false, true)
+        val privateCursor = context?.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
         val groupSubsequentCalls = context?.config?.groupSubsequentCalls ?: false
         RecentsHelper(context).getRecentCalls(groupSubsequentCalls, MIN_RECENTS_THRESHOLD, allRecentCalls) { recents ->
             ContactsHelper(context).getContacts(showOnlyContactsWithNumbers = true) { contacts ->

--- a/app/src/main/kotlin/org/fossify/phone/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/phone/fragments/RecentsFragment.kt
@@ -61,8 +61,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
     override fun refreshItems(callback: (() -> Unit)?) {
         val privateCursor = context?.getMyContactsCursor(false, true)
         val groupSubsequentCalls = context?.config?.groupSubsequentCalls ?: false
-        val querySize = allRecentCalls.size.coerceAtLeast(MIN_RECENTS_THRESHOLD)
-        RecentsHelper(context).getRecentCalls(groupSubsequentCalls, querySize) { recents ->
+        RecentsHelper(context).getRecentCalls(groupSubsequentCalls, MIN_RECENTS_THRESHOLD, allRecentCalls) { recents ->
             ContactsHelper(context).getContacts(showOnlyContactsWithNumbers = true) { contacts ->
                 val privateContacts = MyContactsContentProvider.getContacts(context, privateCursor)
 
@@ -126,8 +125,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
     private fun getMoreRecentCalls() {
         val privateCursor = context?.getMyContactsCursor(false, true)
         val groupSubsequentCalls = context?.config?.groupSubsequentCalls ?: false
-        val querySize = allRecentCalls.size.plus(MIN_RECENTS_THRESHOLD)
-        RecentsHelper(context).getRecentCalls(groupSubsequentCalls, querySize) { recents ->
+        RecentsHelper(context).getRecentCalls(groupSubsequentCalls, MIN_RECENTS_THRESHOLD, allRecentCalls) { recents ->
             ContactsHelper(context).getContacts(showOnlyContactsWithNumbers = true) { contacts ->
                 val privateContacts = MyContactsContentProvider.getContacts(context, privateCursor)
 

--- a/app/src/main/kotlin/org/fossify/phone/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/RecentsHelper.kt
@@ -77,10 +77,10 @@ class RecentsHelper(private val context: Context) {
         var selection: String? = null
         var selectionParams: Array<String>? = null
 
-        val lastId = previousRecents.lastOrNull()?.id
-        if (lastId != null) {
-            selection = "${Calls._ID} < ?"
-            selectionParams = arrayOf(lastId.toString())
+        val lastDate = previousRecents.lastOrNull()?.startTS
+        if (lastDate != null) {
+            selection = "${Calls.DATE} < ?"
+            selectionParams = arrayOf((lastDate * 1000L).toString())
         }
 
         val cursor = if (isNougatPlus()) {

--- a/app/src/main/kotlin/org/fossify/phone/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/RecentsHelper.kt
@@ -13,12 +13,20 @@ import org.fossify.phone.extensions.getAvailableSIMCardLabels
 import org.fossify.phone.models.RecentCall
 
 class RecentsHelper(private val context: Context) {
-    private val COMPARABLE_PHONE_NUMBER_LENGTH = 9
-    private val QUERY_LIMIT = 200
+    companion object {
+        private const val COMPARABLE_PHONE_NUMBER_LENGTH = 9
+        private const val QUERY_LIMIT = 200
+    }
+
     private val contentUri = Calls.CONTENT_URI
 
-    fun getRecentCalls(groupSubsequentCalls: Boolean, maxSize: Int = QUERY_LIMIT, previousRecents: List<RecentCall> = ArrayList(), callback: (List<RecentCall>) -> Unit) {
-        val privateCursor = context.getMyContactsCursor(false, true)
+    fun getRecentCalls(
+        groupSubsequentCalls: Boolean,
+        maxSize: Int = QUERY_LIMIT,
+        previousRecents: List<RecentCall> = ArrayList(),
+        callback: (List<RecentCall>) -> Unit,
+    ) {
+        val privateCursor = context.getMyContactsCursor(favoritesOnly = false, withPhoneNumbersOnly = true)
         ensureBackgroundThread {
             if (!context.hasPermission(PERMISSION_READ_CALL_LOG)) {
                 callback(ArrayList())
@@ -37,8 +45,13 @@ class RecentsHelper(private val context: Context) {
     }
 
     @SuppressLint("NewApi")
-    private fun getRecents(contacts: List<Contact>, groupSubsequentCalls: Boolean, maxSize: Int, previousRecents: List<RecentCall>, callback: (List<RecentCall>) -> Unit) {
-
+    private fun getRecents(
+        contacts: List<Contact>,
+        groupSubsequentCalls: Boolean,
+        maxSize: Int,
+        previousRecents: List<RecentCall>,
+        callback: (List<RecentCall>) -> Unit,
+    ) {
         val recentCalls = mutableListOf<RecentCall>()
         var previousRecentCallFrom = ""
         var previousStartTS = 0
@@ -232,8 +245,8 @@ class RecentsHelper(private val context: Context) {
     }
 
     fun restoreRecentCalls(activity: SimpleActivity, objects: List<RecentCall>, callback: () -> Unit) {
-        activity.handlePermission(PERMISSION_WRITE_CALL_LOG) {
-            if (it) {
+        activity.handlePermission(PERMISSION_WRITE_CALL_LOG) { granted ->
+            if (granted) {
                 ensureBackgroundThread {
                     val values = objects
                         .sortedBy { it.startTS }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Removed call history limit of 200 entries.
- DB queries now always take only 30 entries, it doesn't overwrite entries fetched before.
- Tested on phones with Android 13 (see the screenshot) and Android 6 (there was a different query for older OS versions).

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

<img src="https://github.com/FossifyOrg/Phone/assets/85929121/facb2ba5-b5f3-4de1-88f0-d70696490eaf" width="350">

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #125 

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
