### PR TITLE
Reset dialpad after calling (#136)

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
@@ -347,6 +347,9 @@ class DialpadActivity : SimpleActivity() {
                     startCallIntent(number)
                 }
             }
+            Handler().postDelayed({
+                binding.dialpadInput.setText("")
+            }, 1000)
         } else {
             RecentsHelper(this).getRecentCalls(groupSubsequentCalls = false, maxSize = 1) {
                 val mostRecentNumber = it.firstOrNull()?.phoneNumber

--- a/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
@@ -347,6 +347,7 @@ class DialpadActivity : SimpleActivity() {
                     startCallIntent(number)
                 }
             }
+
             Handler().postDelayed({
                 binding.dialpadInput.setText("")
             }, 1000)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Added resetting dialpad text after calling.
- Added a delay, so it doesn't reset instantly before user see the call being performed.
- This behavior is also in other dialer apps. Also, since we can revert the last called number by tapping the call button with empty text, there's no reason to keep the previously called number.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/FossifyOrg/Phone/assets/85929121/9ef18e14-99a6-4157-a652-151ef1663ec4

- After:

https://github.com/FossifyOrg/Phone/assets/85929121/5a9d4bab-f5da-4dcd-81a6-172fd2d1584b

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #136 

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
