### PR TITLE
Add accessibility options

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/activities/CallActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/CallActivity.kt
@@ -79,6 +79,20 @@ class CallActivity : SimpleActivity() {
         addLockScreenFlags()
         CallManager.addListener(callCallback)
         updateCallContactInfo(CallManager.getPrimaryCall())
+
+        binding.apply {
+            if (!isSpeakerOn && config.speakerAutoOn) {
+                callToggleSpeaker.performClick()
+            }
+            if (config.volumeAutoSet) {
+                val volumePercentage = audioManager.getStreamMaxVolume(AudioManager.STREAM_VOICE_CALL) * (config.volumeAutoSetPercent / 100.0)
+                audioManager.setStreamVolume(AudioManager.STREAM_VOICE_CALL, volumePercentage.toInt(), 0)
+            }
+            if (config.accessibilityLayout) {
+                callToggleSpeaker.layoutParams.height = resources.getDimensionPixelSize(R.dimen.dialpad_button_size_large)
+                callToggleSpeaker.layoutParams.width = resources.getDimensionPixelSize(R.dimen.dialpad_button_size_large)
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent?) {
@@ -674,6 +688,8 @@ class CallActivity : SimpleActivity() {
             updateCallState(phoneState.active)
             updateCallOnHoldState(phoneState.onHold)
         }
+        if (config.accessibilityLayout)
+            hideButtonsForAccessibilityLayout()
 
         updateCallAudioState(CallManager.getCallAudioRoute())
     }
@@ -856,6 +872,16 @@ class CallActivity : SimpleActivity() {
         } else {
             view.background.applyColorFilter(getInactiveButtonColor())
             view.applyColorFilter(getProperBackgroundColor().getContrastColor())
+        }
+    }
+
+    private fun hideButtonsForAccessibilityLayout() {
+        binding.apply {
+            arrayOf(
+                callToggleMicrophone, callDialpad, callToggleHold, callAdd, callSwap, callMerge, callManage
+            ).forEach { imageView ->
+                imageView.visibility = View.GONE
+            }
         }
     }
 }

--- a/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.Menu
+import android.widget.SeekBar
 import androidx.activity.result.contract.ActivityResultContracts
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
@@ -86,6 +87,10 @@ class SettingsActivity : SimpleActivity() {
         setupAlwaysShowFullscreen()
         setupCallsExport()
         setupCallsImport()
+        setupAccessibilityLayout()
+        setupSpeakerAutoOn()
+        setupVolumeAutoSet()
+        setupVolumeAutoSetPercent()
         updateTextColors(binding.settingsHolder)
 
         binding.apply {
@@ -377,6 +382,57 @@ class SettingsActivity : SimpleActivity() {
             } catch (e: Exception) {
                 showErrorToast(e)
             }
+        }
+    }
+
+    private fun setupAccessibilityLayout() {
+        binding.apply {
+            settingsAccessibilityLayout.isChecked = config.accessibilityLayout
+            settingsAccessibilityLayoutHolder.setOnClickListener {
+                settingsAccessibilityLayout.toggle()
+                config.accessibilityLayout = settingsAccessibilityLayout.isChecked
+            }
+        }
+    }
+
+    private fun setupSpeakerAutoOn() {
+        binding.apply {
+            settingsSpeakerAutoOn.isChecked = config.speakerAutoOn
+            settingsSpeakerAutoOnHolder.setOnClickListener {
+                settingsSpeakerAutoOn.toggle()
+                config.speakerAutoOn = settingsSpeakerAutoOn.isChecked
+            }
+        }
+    }
+
+    private fun setupVolumeAutoSet() {
+        binding.apply {
+            settingsVolumeAutoSet.isChecked = config.volumeAutoSet
+            settingsVolumeAutoSetHolder.setOnClickListener {
+                settingsVolumeAutoSet.toggle()
+                config.volumeAutoSet = settingsVolumeAutoSet.isChecked
+            }
+        }
+    }
+
+    private fun setupVolumeAutoSetPercent() {
+        binding.apply {
+            settingsVolumeAutoSetPercent.progress = config.volumeAutoSetPercent
+            settingsVolumeAutoSet.text = getString(R.string.volume_auto_set, config.volumeAutoSetPercent.toString())
+            settingsVolumeAutoSetPercent.max = 100
+
+            settingsVolumeAutoSetPercent.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                    settingsVolumeAutoSet.text = getString(R.string.volume_auto_set, progress.toString())
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar) {
+                }
+
+                override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    config.volumeAutoSetPercent = settingsVolumeAutoSetPercent.progress
+                }
+            })
         }
     }
 }

--- a/app/src/main/kotlin/org/fossify/phone/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Config.kt
@@ -89,4 +89,20 @@ class Config(context: Context) : BaseConfig(context) {
     var alwaysShowFullscreen: Boolean
         get() = prefs.getBoolean(ALWAYS_SHOW_FULLSCREEN, false)
         set(alwaysShowFullscreen) = prefs.edit().putBoolean(ALWAYS_SHOW_FULLSCREEN, alwaysShowFullscreen).apply()
+
+    var accessibilityLayout: Boolean
+        get() = prefs.getBoolean(ACCESSIBILITY_LAYOUT, false)
+        set(accessibilityLayout) = prefs.edit().putBoolean(ACCESSIBILITY_LAYOUT, accessibilityLayout).apply()
+
+    var speakerAutoOn: Boolean
+        get() = prefs.getBoolean(SPEAKER_AUTO_ON, false)
+        set(speakerAutoOn) = prefs.edit().putBoolean(SPEAKER_AUTO_ON, speakerAutoOn).apply()
+
+    var volumeAutoSet: Boolean
+        get() = prefs.getBoolean(VOLUME_AUTO_SET, false)
+        set(volumeAutoSet) = prefs.edit().putBoolean(VOLUME_AUTO_SET, volumeAutoSet).apply()
+
+    var volumeAutoSetPercent: Int
+        get() = prefs.getInt(VOLUME_AUTO_SET_PERCENT, 100)
+        set(volumeAutoSetPercent) = prefs.edit().putInt(VOLUME_AUTO_SET_PERCENT, volumeAutoSetPercent).apply()
 }

--- a/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
@@ -19,6 +19,10 @@ const val DIALPAD_VIBRATION = "dialpad_vibration"
 const val DIALPAD_BEEPS = "dialpad_beeps"
 const val HIDE_DIALPAD_NUMBERS = "hide_dialpad_numbers"
 const val ALWAYS_SHOW_FULLSCREEN = "always_show_fullscreen"
+const val ACCESSIBILITY_LAYOUT = "accessibility_layout"
+const val SPEAKER_AUTO_ON = "speaker_auto_on"
+const val VOLUME_AUTO_SET = "volume_auto_set"
+const val VOLUME_AUTO_SET_PERCENT = "volume_auto_set_percent"
 
 const val ALL_TABS_MASK = TAB_CONTACTS or TAB_FAVORITES or TAB_CALL_HISTORY
 

--- a/app/src/main/kotlin/org/fossify/phone/services/CallService.kt
+++ b/app/src/main/kotlin/org/fossify/phone/services/CallService.kt
@@ -28,6 +28,11 @@ class CallService : InCallService() {
     }
 
     override fun onCallAdded(call: Call) {
+        // Disable call waiting if accessibility layout is enabled
+        if (config.accessibilityLayout && CallManager.getPhoneState() != NoCall) {
+            call.disconnect()
+            return
+        }
         super.onCallAdded(call)
         CallManager.onCallAdded(call)
         CallManager.inCallService = this

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -335,6 +335,76 @@
             </RelativeLayout>
 
             <include
+                android:id="@+id/settings_accessibility_divider"
+                layout="@layout/divider" />
+
+            <TextView
+                android:id="@+id/settings_accesibility_layout"
+                style="@style/SettingsSectionLabelStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/accessibility" />
+
+            <RelativeLayout
+                android:id="@+id/settings_accessibility_layout_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <org.fossify.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_accessibility_layout"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/accessibility_layout" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/settings_speaker_auto_on_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <org.fossify.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_speaker_auto_on"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/speaker_auto_on" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/settings_volume_auto_set_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <org.fossify.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_volume_auto_set"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/volume_auto_set" />
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/settings_volume_auto_set_percent_holder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <SeekBar
+                    android:id="@+id/settings_volume_auto_set_percent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/medium_margin"
+                    android:layout_marginRight="@dimen/medium_margin"
+                    android:progress="10" />
+            </RelativeLayout>
+
+            <include
                 android:id="@+id/settings_dialpad_divider"
                 layout="@layout/divider" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="dialpad_button_size">68dp</dimen>
+    <dimen name="dialpad_button_size_large">80dp</dimen>
     <dimen name="dialpad_button_size_small">50dp</dimen>
     <dimen name="incoming_call_arrow_size">50dp</dimen>
     <dimen name="incoming_call_button_size">72dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,10 @@
     <string name="audio_route_wired_or_earpiece">Wired or Earpiece</string>
     <string name="choose_audio_route">Choose audio route</string>
     <string name="calling_blocked_number">The number you are calling is blocked</string>
+    <string name="accessibility">Accessibility</string>
+    <string name="accessibility_layout">Only show speaker button in-call</string>
+    <string name="speaker_auto_on">Automatically turn on in-call speaker</string>
+    <string name="volume_auto_set">Automatically set in-call volume to %s%%</string>
 
     <!-- Speed dial -->
     <string name="speed_dial">Speed dial</string>


### PR DESCRIPTION
Hello, it seems that issues are not enabled on this repo so I'll put it all in the PR.

I've been looking for a dialer with very simplified usage to assist individuals with mental impairments such as Alzheimer's and dementia and those with limited dexterity in their limbs. Allowing such individuals to have an easily usable device greatly helps them to keep in contact with those they depend on. Not having found a completely suitable dialer, I've been able to make some small changes to this one that works well and would like to make it available to others who may have similar requirements.

## Problems
Dialing has been simplified on Android by either using voice commands or by using Contact shortcuts on the phone that can instantly dial a person by touching their name or picture from the home screen. However, once inside the call, there are still challenges for the impaired. The dialer has several buttons for "advanced" usage such as mute, hold, conference calls, etc. These buttons are not used by the mentally impaired and they are easily touched by accident, especially since they are located near the edge of the phone. It also is easy to mix these buttons up with ones that are generally useful. Similarly, call volume buttons are easily pressed simply by holding the phone. This can cause a lot of frustration for the parties involved.

## Solutions
Provide options to simplify both the layout and functionality of the phone. Keep the buttons closer to the center of the UI. Provide the ability to automatically turn on critical functionality.

To this end, I've added the following configurations:
- An option to reduce the number of in-call buttons to two: Speaker and End Call. Make the speaker button larger and centered.
- The ability to automatically turn on the in-call speaker
- Automatically adjust to a pre-set in-call volume. 

I have been personally working with a patient to refine this usage over time and can attest to how much better this makes life.

A screenshot of the configuration changes:

<img src="https://github.com/FossifyOrg/Phone/assets/33729384/cb6cfefb-d62e-4cbd-aa19-b242b7ff0c59)"  width="300" height="600" />

A screenshot of the in-call layout with the option to only show the speaker button:

<img src="https://github.com/FossifyOrg/Phone/assets/33729384/bebaeaec-f9a4-4db0-9dcb-2052fafac00f"  width="300" height="600" />

Without the extra options enabled, this should not affect any existing functionality.


