### PR TITLE
Added resetting dialpad on dialing through tapping searched items

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
@@ -313,6 +313,9 @@ class DialpadActivity : SimpleActivity() {
             } else {
                 startCallIntent(contact.getPrimaryNumber() ?: return@ContactsAdapter)
             }
+            Handler().postDelayed({
+                binding.dialpadInput.setText("")
+            }, 1000)
         }.apply {
             binding.dialpadList.adapter = this
         }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
It fixes uncovered path for resetting dialpad as mentioned in this comment: https://github.com/FossifyOrg/Phone/pull/145#issuecomment-2132859854.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

https://github.com/FossifyOrg/Phone/assets/85929121/41f61c39-9c15-4d48-88b4-66703f824974

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
