### PR TITLE
Added call confirmation to three dots menu in Call History (#240)

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
@@ -20,7 +20,6 @@ import android.view.ViewConfiguration
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.reddit.indicatorfastscroll.FastScrollItemIndicator
-import org.fossify.commons.dialogs.CallConfirmationDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.*
 import org.fossify.commons.models.contacts.Contact
@@ -306,13 +305,7 @@ class DialpadActivity : SimpleActivity() {
             highlightText = text
         ) {
             val contact = it as Contact
-            if (config.showCallConfirmation) {
-                CallConfirmationDialog(this@DialpadActivity, contact.getNameToDisplay()) {
-                    startCallIntent(contact.getPrimaryNumber() ?: return@CallConfirmationDialog)
-                }
-            } else {
-                startCallIntent(contact.getPrimaryNumber() ?: return@ContactsAdapter)
-            }
+            startCallWithConfirmationCheck(contact.getPrimaryNumber() ?: return@ContactsAdapter, contact.getNameToDisplay())
             Handler().postDelayed({
                 binding.dialpadInput.setText("")
             }, 1000)
@@ -334,21 +327,9 @@ class DialpadActivity : SimpleActivity() {
     private fun initCall(number: String = binding.dialpadInput.value, handleIndex: Int) {
         if (number.isNotEmpty()) {
             if (handleIndex != -1 && areMultipleSIMsAvailable()) {
-                if (config.showCallConfirmation) {
-                    CallConfirmationDialog(this, number) {
-                        callContactWithSim(number, handleIndex == 0)
-                    }
-                } else {
-                    callContactWithSim(number, handleIndex == 0)
-                }
+                callContactWithSimWithConfirmationCheck(number, number, handleIndex == 0)
             } else {
-                if (config.showCallConfirmation) {
-                    CallConfirmationDialog(this, number) {
-                        startCallIntent(number)
-                    }
-                } else {
-                    startCallIntent(number)
-                }
+                startCallWithConfirmationCheck(number, number)
             }
 
             Handler().postDelayed({

--- a/app/src/main/kotlin/org/fossify/phone/adapters/RecentCallsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/phone/adapters/RecentCallsAdapter.kt
@@ -12,6 +12,7 @@ import android.widget.PopupMenu
 import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import org.fossify.commons.adapters.MyRecyclerViewListAdapter
+import org.fossify.commons.dialogs.CallConfirmationDialog
 import org.fossify.commons.dialogs.ConfirmationDialog
 import org.fossify.commons.dialogs.FeatureLockedDialog
 import org.fossify.commons.extensions.*
@@ -177,12 +178,28 @@ class RecentCallsAdapter(
 
     private fun callContact(useSimOne: Boolean) {
         val phoneNumber = getSelectedPhoneNumber() ?: return
-        activity.callContactWithSim(phoneNumber, useSimOne)
+        val name = getSelectedName() ?: return
+
+        if (activity.config.showCallConfirmation) {
+            CallConfirmationDialog(activity, name) {
+                activity.callContactWithSim(phoneNumber, useSimOne)
+            }
+        } else {
+            activity.callContactWithSim(phoneNumber, useSimOne)
+        }
     }
 
     private fun callContact() {
         val phoneNumber = getSelectedPhoneNumber() ?: return
-        (activity as SimpleActivity).startCallIntent(phoneNumber)
+        val name = getSelectedName() ?: return
+
+        if (activity.config.showCallConfirmation) {
+            CallConfirmationDialog(activity, name) {
+                (activity as SimpleActivity).startCallIntent(phoneNumber)
+            }
+        } else {
+            (activity as SimpleActivity).startCallIntent(phoneNumber)
+        }
     }
 
     private fun removeDefaultSIM() {
@@ -313,6 +330,8 @@ class RecentCallsAdapter(
         .filter { selectedKeys.contains(it.getItemId()) }
 
     private fun getSelectedPhoneNumber() = getSelectedItems().firstOrNull()?.phoneNumber
+
+    private fun getSelectedName() = getSelectedItems().firstOrNull()?.name
 
     private fun showPopupMenu(view: View, call: RecentCall) {
         finishActMode()

--- a/app/src/main/kotlin/org/fossify/phone/adapters/RecentCallsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/phone/adapters/RecentCallsAdapter.kt
@@ -12,7 +12,6 @@ import android.widget.PopupMenu
 import androidx.recyclerview.widget.DiffUtil
 import com.bumptech.glide.Glide
 import org.fossify.commons.adapters.MyRecyclerViewListAdapter
-import org.fossify.commons.dialogs.CallConfirmationDialog
 import org.fossify.commons.dialogs.ConfirmationDialog
 import org.fossify.commons.dialogs.FeatureLockedDialog
 import org.fossify.commons.extensions.*
@@ -180,26 +179,14 @@ class RecentCallsAdapter(
         val phoneNumber = getSelectedPhoneNumber() ?: return
         val name = getSelectedName() ?: return
 
-        if (activity.config.showCallConfirmation) {
-            CallConfirmationDialog(activity, name) {
-                activity.callContactWithSim(phoneNumber, useSimOne)
-            }
-        } else {
-            activity.callContactWithSim(phoneNumber, useSimOne)
-        }
+        activity.callContactWithSimWithConfirmationCheck(phoneNumber, name, useSimOne)
     }
 
     private fun callContact() {
         val phoneNumber = getSelectedPhoneNumber() ?: return
         val name = getSelectedName() ?: return
 
-        if (activity.config.showCallConfirmation) {
-            CallConfirmationDialog(activity, name) {
-                (activity as SimpleActivity).startCallIntent(phoneNumber)
-            }
-        } else {
-            (activity as SimpleActivity).startCallIntent(phoneNumber)
-        }
+        (activity as SimpleActivity).startCallWithConfirmationCheck(phoneNumber, name)
     }
 
     private fun removeDefaultSIM() {

--- a/app/src/main/kotlin/org/fossify/phone/extensions/Activity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/extensions/Activity.kt
@@ -9,6 +9,7 @@ import android.telecom.PhoneAccount
 import android.telecom.PhoneAccountHandle
 import android.telecom.TelecomManager
 import org.fossify.commons.activities.BaseSimpleActivity
+import org.fossify.commons.dialogs.CallConfirmationDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.*
 import org.fossify.commons.models.contacts.Contact
@@ -26,6 +27,16 @@ fun SimpleActivity.startCallIntent(recipient: String) {
     }
 }
 
+fun SimpleActivity.startCallWithConfirmationCheck(recipient: String, name: String) {
+    if (config.showCallConfirmation) {
+        CallConfirmationDialog(this, name) {
+            startCallIntent(recipient)
+        }
+    } else {
+        startCallIntent(recipient)
+    }
+}
+
 fun SimpleActivity.launchCreateNewContactIntent() {
     Intent().apply {
         action = Intent.ACTION_INSERT
@@ -39,6 +50,16 @@ fun BaseSimpleActivity.callContactWithSim(recipient: String, useMainSIM: Boolean
         val wantedSimIndex = if (useMainSIM) 0 else 1
         val handle = getAvailableSIMCardLabels().sortedBy { it.id }.getOrNull(wantedSimIndex)?.handle
         launchCallIntent(recipient, handle)
+    }
+}
+
+fun BaseSimpleActivity.callContactWithSimWithConfirmationCheck(recipient: String, name: String, useMainSIM: Boolean) {
+    if (config.showCallConfirmation) {
+        CallConfirmationDialog(this, name) {
+            callContactWithSim(recipient, useMainSIM)
+        }
+    } else {
+        callContactWithSim(recipient, useMainSIM)
     }
 }
 

--- a/app/src/main/kotlin/org/fossify/phone/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/phone/fragments/RecentsFragment.kt
@@ -2,7 +2,6 @@ package org.fossify.phone.fragments
 
 import android.content.Context
 import android.util.AttributeSet
-import org.fossify.commons.dialogs.CallConfirmationDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.*
 import org.fossify.commons.models.contacts.Contact
@@ -12,6 +11,7 @@ import org.fossify.phone.activities.SimpleActivity
 import org.fossify.phone.adapters.RecentCallsAdapter
 import org.fossify.phone.databinding.FragmentRecentsBinding
 import org.fossify.phone.extensions.config
+import org.fossify.phone.extensions.startCallWithConfirmationCheck
 import org.fossify.phone.helpers.RecentsHelper
 import org.fossify.phone.interfaces.RefreshItemsListener
 import org.fossify.phone.models.CallLogItem
@@ -141,13 +141,7 @@ class RecentsFragment(
                     },
                     itemClick = {
                         val recentCall = it as RecentCall
-                        if (context.config.showCallConfirmation) {
-                            CallConfirmationDialog(activity as SimpleActivity, recentCall.name) {
-                                activity?.launchCallIntent(recentCall.phoneNumber)
-                            }
-                        } else {
-                            activity?.launchCallIntent(recentCall.phoneNumber)
-                        }
+                        activity?.startCallWithConfirmationCheck(recentCall.phoneNumber, recentCall.name)
                     }
                 )
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Added call confirmation to three dots menu in Call History, as it was the only place in the app where there was no confirmation.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

https://github.com/user-attachments/assets/60f3396c-8a54-4e2d-94fd-5345d0e773b3

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #240 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
