### PR TITLE
Add dynamic shortcuts for speed dial entries

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Config.kt
@@ -20,7 +20,7 @@ class Config(context: Context) : BaseConfig(context) {
         val speedDialValues = Gson().fromJson<ArrayList<SpeedDial>>(speedDial, speedDialType) ?: ArrayList(1)
 
         for (i in 1..9) {
-            val speedDial = SpeedDial(i, "", "")
+            val speedDial = SpeedDial(i, "", "", "")
             if (speedDialValues.firstOrNull { it.id == i } == null) {
                 speedDialValues.add(speedDial)
             }

--- a/app/src/main/kotlin/org/fossify/phone/models/SpeedDial.kt
+++ b/app/src/main/kotlin/org/fossify/phone/models/SpeedDial.kt
@@ -1,5 +1,5 @@
 package org.fossify.phone.models
 
-data class SpeedDial(val id: Int, var number: String, var displayName: String) {
+data class SpeedDial(val id: Int, var number: String, var displayName: String, var photoUri: String) {
     fun isValid() = number.trim().isNotEmpty()
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- `photoUri` is added to the `SpeedDial` class for the shortcut's icon.
- It uses `ACTION_DIAL` instead of `ACTION_CALL` if calling permission is denied.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
