### PR TITLE
Implement missed call notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -200,6 +200,15 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".receivers.MissedCallReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.telecom.action.SHOW_MISSED_CALLS_NOTIFICATION" />
+            </intent-filter>
+        </receiver>
+
         <activity-alias
             android:name=".activities.SplashActivity.Red"
             android:enabled="false"

--- a/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
@@ -27,5 +27,6 @@ val tabsList = arrayListOf(TAB_CONTACTS, TAB_FAVORITES, TAB_CALL_HISTORY)
 private const val PATH = "org.fossify.phone.action."
 const val ACCEPT_CALL = PATH + "accept_call"
 const val DECLINE_CALL = PATH + "decline_call"
+const val MISSED_CALLS = PATH + "missed_call"
 
 const val DIALPAD_TONE_LENGTH_MS = 150L // The length of DTMF tones in milliseconds

--- a/app/src/main/kotlin/org/fossify/phone/receivers/MissedCallReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/phone/receivers/MissedCallReceiver.kt
@@ -1,0 +1,77 @@
+package org.fossify.phone.receivers
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.net.Uri
+import android.os.Build
+import android.telecom.TelecomManager
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import org.fossify.commons.extensions.getLaunchIntent
+import org.fossify.commons.extensions.notificationManager
+import org.fossify.commons.helpers.SimpleContactsHelper
+import org.fossify.phone.R
+import org.fossify.phone.helpers.MISSED_CALLS
+import kotlin.random.Random
+
+@RequiresApi(Build.VERSION_CODES.O)
+class MissedCallReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == TelecomManager.ACTION_SHOW_MISSED_CALLS_NOTIFICATION) {
+            val extras = intent.extras!!
+            val notificationCount = extras.getInt(TelecomManager.EXTRA_NOTIFICATION_COUNT)
+            if (notificationCount != 0) {
+                val phoneNumber = extras.getString(TelecomManager.EXTRA_NOTIFICATION_PHONE_NUMBER)!!
+                val helper = SimpleContactsHelper(context)
+                val name = helper.getNameFromPhoneNumber(phoneNumber)
+                val photoUri = helper.getPhotoUriFromPhoneNumber(phoneNumber)
+
+                val notificationManager = context.notificationManager
+                val channel = NotificationChannel(
+                    "missed_call_channel",
+                    context.getString(R.string.missed_call_channel),
+                    NotificationManager.IMPORTANCE_LOW
+                )
+                notificationManager.createNotificationChannel(channel)
+
+                val pendingIntent = PendingIntent.getActivity(
+                    context, 0, context.getLaunchIntent(), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val callBack = Intent(Intent.ACTION_CALL).apply {
+                    data = Uri.fromParts("tel", phoneNumber, null)
+                }
+                val callBackIntent = PendingIntent.getActivity(
+                    context, 0, callBack, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val smsIntent = Intent(Intent.ACTION_VIEW).apply {
+                    data = Uri.fromParts("sms", phoneNumber, null)
+                }
+                val messageIntent = PendingIntent.getActivity(
+                    context, 0, smsIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val cancel = Intent("android.intent.action.CANCEL_MISSED_CALLS_NOTIFICATION")
+                val cancelIntent = PendingIntent.getActivity(
+                    context, 0, cancel, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val notification = NotificationCompat.Builder(context, "missed_call_channel")
+                    .setSmallIcon(android.R.drawable.sym_call_missed)
+                    .setContentTitle(context.getString(R.string.missed_call))
+                    .setContentText(context.getString(R.string.missed_call_from, name))
+                    .setLargeIcon(Icon.createWithContentUri(photoUri))
+                    .setAutoCancel(true)
+                    .setGroup(MISSED_CALLS)
+                    .setContentIntent(pendingIntent)
+                    .addAction(0, context.getString(R.string.call_back), callBackIntent)
+                    .addAction(0, context.getString(R.string.message), messageIntent)
+                    .setDeleteIntent(cancelIntent)
+                    .build()
+                notificationManager.notify(Random.nextInt(), notification)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,13 @@
     <string name="faq_1_title">I hear incoming calls, but the screen doesn\'t turn on. What can I do?</string>
     <string name="faq_1_text">Such issues can have many device and system specific reasons, hard to say in general. You should look around in your device settings and make sure that the app is allowed to pop up when in background and allow displaying over other apps.</string>
 
+    <!-- Notifications -->
+    <string name="missed_call_channel">Missed Calls</string>
+    <string name="missed_call">Missed call</string>
+    <string name="missed_call_from">Missed call from %s</string>
+    <string name="call_back">Call back</string>
+    <string name="message">Message</string>
+
     <!--
         Haven't found some strings? There's more at
         https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/res


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Implement `BroadcastReceiver` on a new class `MissedCallReceiver`. This way, the system still manages missed calls but Fossify handles the broadcasts instead of the pre-installed dialer app.
- Additional actions include "call back" and "message".
- Clicking the notification will open the app.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #83

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).