### PR TITLE
Fix missing .json file extension when exporting call history

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
@@ -335,7 +335,7 @@ class SettingsActivity : SimpleActivity() {
     private fun setupCallsExport() {
         binding.settingsExportCallsHolder.setOnClickListener {
             ExportCallHistoryDialog(this) { filename ->
-                saveDocument.launch(filename)
+                saveDocument.launch("$filename.json")
             }
         }
     }


### PR DESCRIPTION
Very similar to FossifyOrg/Notes#14 (which has a more detailed commit message). Basically, some file pickers don't automatically append the extension, so we should do it ourselves. It doesn't cause problems.

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fix missing .json file extension when exporting call history when using some file pickers

#### Fixes the following issue(s)
- Not tracked

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
