### PR TITLE
Adjust conference call name and image colors

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/adapters/ConferenceCallsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/phone/adapters/ConferenceCallsAdapter.kt
@@ -5,6 +5,7 @@ import android.view.Menu
 import android.view.ViewGroup
 import com.bumptech.glide.Glide
 import org.fossify.commons.adapters.MyRecyclerViewAdapter
+import org.fossify.commons.extensions.applyColorFilter
 import org.fossify.commons.extensions.toast
 import org.fossify.commons.helpers.LOWER_ALPHA
 import org.fossify.commons.helpers.SimpleContactsHelper
@@ -50,11 +51,14 @@ class ConferenceCallsAdapter(
                 getCallContact(itemView.context, call) { callContact ->
                     root.post {
                         itemConferenceCallName.text = callContact.name.ifEmpty { itemView.context.getString(R.string.unknown_caller) }
+                        itemConferenceCallName.setTextColor(textColor)
+                        val contactDrawable = activity.getDrawable(R.drawable.ic_person_vector)
+                        contactDrawable?.applyColorFilter(textColor)
                         SimpleContactsHelper(activity).loadContactImage(
                             callContact.photoUri,
                             itemConferenceCallImage,
                             callContact.name,
-                            activity.getDrawable(R.drawable.ic_person_vector)
+                            contactDrawable
                         )
                     }
                 }
@@ -63,6 +67,7 @@ class ConferenceCallsAdapter(
                 val canDisconnect = call.hasCapability(Call.Details.CAPABILITY_DISCONNECT_FROM_CONFERENCE)
                 itemConferenceCallSplit.isEnabled = canSeparate
                 itemConferenceCallSplit.alpha = if (canSeparate) 1.0f else LOWER_ALPHA
+                itemConferenceCallSplit.setColorFilter(textColor)
                 itemConferenceCallSplit.setOnClickListener {
                     call.splitFromConference()
                     data.removeAt(position)
@@ -81,6 +86,7 @@ class ConferenceCallsAdapter(
 
                 itemConferenceCallEnd.isEnabled = canDisconnect
                 itemConferenceCallEnd.alpha = if (canDisconnect) 1.0f else LOWER_ALPHA
+                itemConferenceCallEnd.setColorFilter(textColor)
                 itemConferenceCallEnd.setOnClickListener {
                     call.disconnect()
                     data.removeAt(position)


### PR DESCRIPTION
Set the conference call name text color and the contact image tint to the proper text color.

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Updated colors in ConferenceCallsAdapter.kt

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
<img alt="Screenshot_20250412_102315" src="https://github.com/user-attachments/assets/cdf339c5-7d4a-4f95-979a-769e7cd93562" width=180 />

- After:
<img alt="Screenshot_20250412_102546" src="https://github.com/user-attachments/assets/5ac1f0a8-d6c4-4355-8793-33b311bc1bd9" width=180 />


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #https://github.com/FossifyOrg/Phone/issues/359

#### Relies on the following changes

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Phone/blob/master/CONTRIBUTING.md).
