### PR TITLE
fix: Made ACCEPT/DECLINE_CALL values match the ones declared in the manifest.

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
@@ -25,7 +25,7 @@ const val ALL_TABS_MASK = TAB_CONTACTS or TAB_FAVORITES or TAB_CALL_HISTORY
 val tabsList = arrayListOf(TAB_CONTACTS, TAB_FAVORITES, TAB_CALL_HISTORY)
 
 private const val PATH = "org.fossify.phone.action."
-const val ACCEPT_CALL = PATH + "accept_call"
-const val DECLINE_CALL = PATH + "decline_call"
+const val ACCEPT_CALL = PATH + "ACCEPT_CALL"
+const val DECLINE_CALL = PATH + "DECLINE_CALL"
 
 const val DIALPAD_TONE_LENGTH_MS = 150L // The length of DTMF tones in milliseconds


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Updated the constants for the actions to match [the ones in the manifest](https://github.com/grigorye/Phone/blob/88948890acd22776de2178c264c6bb4799730d62/app/src/main/AndroidManifest.xml#L198-L200). This is particularly necessary for CallActionReceiver to [actually handle](https://github.com/grigorye/Phone/blob/88948890acd22776de2178c264c6bb4799730d62/app/src/main/kotlin/org/fossify/phone/receivers/CallActionReceiver.kt#L14-L20) intents sent from the other apps.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
