### PR TITLE
fix: make call action receiver private

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -193,12 +193,7 @@
         <receiver
             android:name=".receivers.CallActionReceiver"
             android:enabled="true"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="org.fossify.phone.action.ACCEPT_CALL" />
-                <action android:name="org.fossify.phone.action.DECLINE_CALL" />
-            </intent-filter>
-        </receiver>
+            android:exported="false" />
 
         <activity-alias
             android:name=".activities.SplashActivity.Red"

--- a/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Constants.kt
@@ -25,7 +25,7 @@ const val ALL_TABS_MASK = TAB_CONTACTS or TAB_FAVORITES or TAB_CALL_HISTORY
 val tabsList = arrayListOf(TAB_CONTACTS, TAB_FAVORITES, TAB_CALL_HISTORY)
 
 private const val PATH = "org.fossify.phone.action."
-const val ACCEPT_CALL = PATH + "accept_call"
-const val DECLINE_CALL = PATH + "decline_call"
+const val ACCEPT_CALL = PATH + "ACCEPT_CALL"
+const val DECLINE_CALL = PATH + "DECLINE_CALL"
 
 const val DIALPAD_TONE_LENGTH_MS = 150L // The length of DTMF tones in milliseconds


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Made CallActionReceiver private. The app shouldn't allow third-party apps to accept/end calls.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Not tracked. More info in https://github.com/FossifyOrg/Phone/pull/489#pullrequestreview-3060949531

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
