### PR TITLE
fix: display phone numbers even when number type is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed missing phone number in call history details ([#526])
 
 ## [1.6.1] - 2025-07-31
 ### Changed
@@ -159,6 +161,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#357]: https://github.com/FossifyOrg/Phone/issues/357
 [#359]: https://github.com/FossifyOrg/Phone/issues/359
 [#378]: https://github.com/FossifyOrg/Phone/issues/378
+[#526]: https://github.com/FossifyOrg/Phone/issues/526
 
 [Unreleased]: https://github.com/FossifyOrg/Phone/compare/1.6.1...HEAD
 [1.6.1]: https://github.com/FossifyOrg/Phone/compare/1.6.0...1.6.1

--- a/app/src/main/kotlin/org/fossify/phone/adapters/RecentCallsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/phone/adapters/RecentCallsAdapter.kt
@@ -453,17 +453,20 @@ class RecentCallsAdapter(
                 }
                 val shouldShowDuration = call.type != Calls.MISSED_TYPE && call.type != Calls.REJECTED_TYPE && call.duration > 0
 
-                if (call.specificType.isNotEmpty()) {
-                    nameToShow = SpannableString("$name - ${call.specificType}")
-
+                if (refreshItemsListener == null) {
                     // show specific number at "Show call details" dialog too
-                    if (refreshItemsListener == null) {
-                        nameToShow = if (formatPhoneNumbers) {
-                            SpannableString("$name - ${call.specificType}, ${call.specificNumber.formatPhoneNumber()}")
-                        } else {
-                            SpannableString("$name - ${call.specificType}, ${call.specificNumber}")
-                        }
-                    }
+                    val typePart = call.specificType
+                        .takeIf { it.isNotBlank() }?.let { " - $it" }.orEmpty()
+
+                    val numPart = call.specificNumber
+                        .takeIf { it.isNotBlank() }
+                        ?.let { if (formatPhoneNumbers) it.formatPhoneNumber() else it }
+                        ?.let { ", $it" }
+                        .orEmpty()
+
+                    nameToShow = SpannableString("$name$typePart$numPart")
+                } else if (call.specificType.isNotBlank()) {
+                    nameToShow = SpannableString("$name - ${call.specificType}")
                 }
 
                 if (call.groupedCalls != null) {


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Phone number is now always displayed in the **Show call details** dialog and is independent from number type availability. The number is still [clipped for longer names](https://github.com/FossifyOrg/Phone/issues/526#issuecomment-3211065873), but that will be handled in another PR.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Phone/issues/526

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
