### PR TITLE
fix: improve speed dial UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 ### Changed
 - Tapping a contact now starts a call; tap the photo for details ([#80])
+- Improved speed dial management UX for contacts with multiple numbers 
+
+### Fixed
+- Fixed speed dial not showing contact name ([#543])
 
 ## [1.6.2] - 2025-08-23
 ### Changed
@@ -179,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#378]: https://github.com/FossifyOrg/Phone/issues/378
 [#526]: https://github.com/FossifyOrg/Phone/issues/526
 [#535]: https://github.com/FossifyOrg/Phone/issues/535
+[#543]: https://github.com/FossifyOrg/Phone/issues/543
 
 [Unreleased]: https://github.com/FossifyOrg/Phone/compare/1.6.2...HEAD
 [1.6.2]: https://github.com/FossifyOrg/Phone/compare/1.6.1...1.6.2

--- a/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
@@ -410,7 +410,7 @@ class DialpadActivity : SimpleActivity() {
         if (binding.dialpadInput.value.length == 1) {
             val speedDial = speedDialValues.firstOrNull { it.id == id }
             if (speedDial?.isValid() == true) {
-                initCall(speedDial.number, speedDial.displayName)
+                initCall(speedDial.number, speedDial.getName(this))
                 return true
             }
         }

--- a/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/DialpadActivity.kt
@@ -376,9 +376,9 @@ class DialpadActivity : SimpleActivity() {
         }
     }
 
-    private fun initCall(number: String = binding.dialpadInput.value) {
+    private fun initCall(number: String = binding.dialpadInput.value, name: String? = null) {
         if (number.isNotEmpty()) {
-            startCallWithConfirmationCheck(number, number)
+            startCallWithConfirmationCheck(number, name ?: number)
             clearInputWithDelay()
         } else {
             RecentsHelper(this).getRecentCalls(queryLimit = 1) {
@@ -410,7 +410,7 @@ class DialpadActivity : SimpleActivity() {
         if (binding.dialpadInput.value.length == 1) {
             val speedDial = speedDialValues.firstOrNull { it.id == id }
             if (speedDial?.isValid() == true) {
-                initCall(speedDial.number)
+                initCall(speedDial.number, speedDial.displayName)
                 return true
             }
         }

--- a/app/src/main/kotlin/org/fossify/phone/activities/ManageSpeedDialActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/ManageSpeedDialActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import com.google.gson.Gson
 import org.fossify.commons.dialogs.RadioGroupDialog
 import org.fossify.commons.extensions.getMyContactsCursor
+import org.fossify.commons.extensions.getPhoneNumberTypeText
 import org.fossify.commons.extensions.updateTextColors
 import org.fossify.commons.extensions.viewBinding
 import org.fossify.commons.helpers.ContactsHelper
@@ -71,7 +72,7 @@ class ManageSpeedDialActivity : SimpleActivity(), RemoveSpeedDialListener {
             SelectContactDialog(this, allContacts) { selectedContact ->
                 if (selectedContact.phoneNumbers.size > 1) {
                     val radioItems = selectedContact.phoneNumbers.mapIndexed { index, item ->
-                        RadioItem(index, item.normalizedNumber, item)
+                        RadioItem(index, "${item.value} (${getPhoneNumberTypeText(item.type, item.label)})", item)
                     }
                     val userPhoneNumbersList = selectedContact.phoneNumbers.map { it.value }
                     val checkedItemId = userPhoneNumbersList.indexOf(clickedContact.number)
@@ -80,6 +81,8 @@ class ManageSpeedDialActivity : SimpleActivity(), RemoveSpeedDialListener {
                         speedDialValues.first { it.id == clickedContact.id }.apply {
                             displayName = selectedContact.getNameToDisplay()
                             number = selectedNumber.normalizedNumber
+                            type = selectedNumber.type
+                            label = selectedNumber.label
                         }
                         updateAdapter()
                     }
@@ -102,6 +105,8 @@ class ManageSpeedDialActivity : SimpleActivity(), RemoveSpeedDialListener {
             speedDialValues.first { it.id == dialId }.apply {
                 displayName = ""
                 number = ""
+                type = null
+                label = null
             }
         }
         updateAdapter()

--- a/app/src/main/kotlin/org/fossify/phone/adapters/SpeedDialAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/phone/adapters/SpeedDialAdapter.kt
@@ -70,7 +70,7 @@ class SpeedDialAdapter(
     private fun setupView(binding: ItemSpeedDialBinding, speedDial: SpeedDial) {
         binding.apply {
             var displayName = "${speedDial.id}. "
-            displayName += if (speedDial.isValid()) speedDial.displayName else ""
+            displayName += if (speedDial.isValid()) speedDial.getName(activity) else ""
 
             speedDialLabel.apply {
                 text = displayName

--- a/app/src/main/kotlin/org/fossify/phone/models/SpeedDial.kt
+++ b/app/src/main/kotlin/org/fossify/phone/models/SpeedDial.kt
@@ -1,5 +1,20 @@
 package org.fossify.phone.models
 
-data class SpeedDial(val id: Int, var number: String, var displayName: String) {
+import android.content.Context
+import org.fossify.commons.extensions.getPhoneNumberTypeText
+
+data class SpeedDial(
+    val id: Int,
+    var number: String,
+    var displayName: String,
+    var type: Int? = null,
+    var label: String? = null
+) {
     fun isValid() = number.trim().isNotEmpty()
+
+    fun getName(context: Context) = if (type != null && label != null) {
+        "$displayName - ${context.getPhoneNumberTypeText(type!!, label!!)}"
+    } else {
+        displayName
+    }
 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Displaying the contact name (with number type) instead of the phone number while speed dialing.
- Formatting numbers and showing their types while choosing the number for speed dialing (in case of contacts with multiple numbers).
- Displaying number type in speed dial management (in case of contacts with multiple numbers).
    - Number type and label are kept in a separate data field, so in case of the language change, types are also translated.

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/1bc5c111-6b6b-4fef-96b0-3de0e7cefcbd" width=179 /> <img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/c5d9d71e-92ff-46a2-9583-635180575086" width=179 /> <img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/967d9f83-3f45-49c3-86e9-783f8b47e543" width=179 />

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/1a247982-68af-4e1b-816e-6862348ab025" width=179 /> <img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/a297a448-262d-47c6-819e-acf17f9b0192" width=179 /> <img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/3d418070-a140-416f-a7aa-3c84ab067626" width=179 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #543 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
