### PR TITLE
ci: trigger v1.8.0 release again

### DIFF
--- a/.fossify/release-marker.txt
+++ b/.fossify/release-marker.txt
@@ -1,2 +1,4 @@
-# Auto-generated file. DO NOT EDIT.
+# Auto-generated file. DO NOT EDIT. 
+
+# EDIT: But why not? 🤷
 1.8.0


### PR DESCRIPTION
After https://github.com/FossifyOrg/.github/pull/112, the GitHub release should go through, and Gplay should fail.
