### PR TITLE
ci: pass secrets to testing build workflow

### DIFF
--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -2,9 +2,10 @@ name: Testing build (on PR)
 
 on:
     pull_request:
-        branches: [ main ]
-        types: [ labeled, opened, synchronize, reopened ]
+        branches: [main]
+        types: [labeled, opened, synchronize, reopened]
 
 jobs:
     call-testing-build-workflow:
         uses: FossifyOrg/.github/.github/workflows/testing-build.yml@main
+        secrets: inherit


### PR DESCRIPTION
Secrets still won't be available to PRs from forks