### PR TITLE
fix: properly highlight search results with accents and diacritics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed overlap between the call screen avatar and the camera notch ([#645])
 - Fixed overlap between the call-on-hold banner and the status bar
-- Fixed highlighting for Search with accents and diacritics
+- Fixed search highlighting for characters with accents and diacritics
 
 ## [1.9.0] - 2025-11-03
 ### Added

--- a/app/src/main/kotlin/org/fossify/phone/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/phone/adapters/ContactsAdapter.kt
@@ -394,7 +394,7 @@ class ContactsAdapter(
                     val normalizedName = name.normalizeString()
                     val normalizedSearchText = textToHighlight.normalizeString()
                     if (normalizedName.contains(normalizedSearchText, true)) {
-                        name.highlightTextPart(textToHighlight, properPrimaryColor)
+                        name.highlightTextPart(normalizedSearchText, properPrimaryColor)
                     } else {
                         var spacedTextToHighlight = textToHighlight
                         val strippedName = name.filterNot { it.isWhitespace() }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [x] Infrastructure / tooling (CI, build, deps, tests)
- [x] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fixed highlighting for Search with accents and diacritics

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - searched with letters without accents and diacritics -> result highlights contain accents and diacritics
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/f38077c3-06b7-459f-9f81-0173595c1cc9" width=178 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Refers to https://github.com/FossifyOrg/Contacts/issues/12

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
