### PR TITLE
fix: open correct contact when reopening details after a call

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/extensions/ActivityExt.kt
+++ b/app/src/main/kotlin/org/fossify/phone/extensions/ActivityExt.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.provider.ContactsContract
 import org.fossify.commons.extensions.isPackageInstalled
 import org.fossify.commons.extensions.launchActivityIntent
-import org.fossify.commons.extensions.launchViewContactIntent
 import org.fossify.commons.helpers.CONTACT_ID
 import org.fossify.commons.helpers.FIRST_CONTACT_ID
 import org.fossify.commons.helpers.IS_PRIVATE
@@ -51,6 +50,9 @@ fun Activity.startContactDetailsIntent(contact: Contact) {
                 ContactsContract.Contacts.CONTENT_LOOKUP_URI,
                 "vnd.android.cursor.dir/person"
             )
+            // launchActivityIntent adds FLAG_ACTIVITY_NEW_TASK; without CLEAR_TASK the receiving
+            // app's existing task is brought forward and re-shows its previously-viewed contact.
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
             launchActivityIntent(this)
         }
     } else {
@@ -60,7 +62,12 @@ fun Activity.startContactDetailsIntent(contact: Contact) {
             val publicUri =
                 Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey)
             runOnUiThread {
-                launchViewContactIntent(publicUri)
+                Intent().apply {
+                    action = ContactsContract.QuickContact.ACTION_QUICK_CONTACT
+                    data = publicUri
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    launchActivityIntent(this)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #783 — picking a contact from Favorites/Contacts after calling a previously-viewed contact opens that previous contact instead of the one just tapped.

## Root cause

`startContactDetailsIntent` in `ActivityExt.kt` launches `ACTION_QUICK_CONTACT` via the commons `launchActivityIntent`, which adds only `FLAG_ACTIVITY_NEW_TASK`. With that flag alone, if the receiving Contacts app's task is still alive from a previous view, Android brings the existing task forward with its old activity stack. The new intent is dropped (the receiver isn't `singleTop` / `singleTask`), so the previously-viewed contact is shown.

This is easy to miss in casual testing — pressing back from the quick-contact view finishes the activity and tears down the task, so the bug only reproduces when the previous quick-contact view is left in the background (the typical flow being: open contact → tap call → end call → return to phone app → tap a different contact).

## Fix

Add `FLAG_ACTIVITY_CLEAR_TASK` so the receiver's task is cleared before launching the new view. Applied to both branches (Fossify Contacts via `ACTION_VIEW`, system Contacts via `ACTION_QUICK_CONTACT`). The `launchViewContactIntent` call was inlined so the flag could be set before `launchActivityIntent` adds `NEW_TASK`.

## Test plan

- [ ] Open Favorites, tap contact A → call A → end call → tap contact B in Favorites → contact B's details appear (previously: contact A reappeared)
- [ ] Repeat the call/return cycle several times → no stale stack of past contacts builds up
- [ ] Plain "tap A → back → tap B" path still works
- [ ] Same flow from the Contacts tab
- [ ] Same flow with Fossify Contacts installed (private-contact branch)