### PR TITLE
fix(lint): declare telephony as optional uses-feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,10 @@
         android:name="android.permission.USE_FINGERPRINT"
         tools:node="remove" />
 
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+
     <queries>
         <package android:name="org.fossify.contacts.debug" />
         <package android:name="org.fossify.contacts" />


### PR DESCRIPTION
## Summary

Unblocks `./gradlew lint` on `main`. The AGP 9.0.1 → 9.2.0 bump (#788) was merged with a failing lint check, and every PR opened against current main now inherits the failure (e.g. #794).

## Root cause

Lint 9.2.0 raises `PermissionImpliesUnsupportedChromeOsHardware` errors at `AndroidManifest.xml:9` and `:10` for `CALL_PHONE` and `CALL_PRIVILEGED`. Both permissions imply `android.hardware.telephony`, but the manifest never declared a matching `<uses-feature>` entry. The existing `app/lint-baseline.xml` was generated against lint 9.0.1 and doesn't cover these new checks (it also notes 4 stale entries that no longer apply under 9.2.0).

## Fix

Add `<uses-feature android:name="android.hardware.telephony" android:required="false" />`. This is the fix lint suggests directly, and `required="false"` is correct here — the app can install on tablets and ChromeOS devices that lack telephony hardware. Dialer code paths that actually need telephony already gate at runtime via `TelephonyManager` / `TelecomManager` capability checks, so this does not change install or runtime behavior on devices that do have telephony.

The 4 stale baseline entries flagged by the new lint version are left for the existing fossifybot baseline-update workflow to clean up — they're warnings, not errors, and don't fail the build.

## Test plan

- [ ] `./gradlew lint` passes locally on `main` after the change
- [ ] Install on a phone — dialer still works as before (no manifest filter excludes it)
- [ ] Verify the app still appears in Play Store / install lists for tablets that lack telephony (would be excluded if `required="true"`)