### PR TITLE
Fix crash when calling back a missed call with a stale SIM handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed crash when tapping "Call back" on a missed call notification when the phone account handle from the intent no longer resolves (e.g. an inactive/locked SIM) ([#134], [#473])
 
 ## [1.11.1] - 2026-02-01
 ### Changed
@@ -243,6 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#118]: https://github.com/FossifyOrg/Phone/issues/118
 [#125]: https://github.com/FossifyOrg/Phone/issues/125
 [#133]: https://github.com/FossifyOrg/Phone/issues/133
+[#134]: https://github.com/FossifyOrg/Phone/issues/134
 [#139]: https://github.com/FossifyOrg/Phone/issues/139
 [#146]: https://github.com/FossifyOrg/Phone/issues/146
 [#147]: https://github.com/FossifyOrg/Phone/issues/147
@@ -260,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#359]: https://github.com/FossifyOrg/Phone/issues/359
 [#378]: https://github.com/FossifyOrg/Phone/issues/378
 [#389]: https://github.com/FossifyOrg/Phone/issues/389
+[#473]: https://github.com/FossifyOrg/Phone/issues/473
 [#526]: https://github.com/FossifyOrg/Phone/issues/526
 [#535]: https://github.com/FossifyOrg/Phone/issues/535
 [#543]: https://github.com/FossifyOrg/Phone/issues/543

--- a/app/src/main/kotlin/org/fossify/phone/extensions/CallExt.kt
+++ b/app/src/main/kotlin/org/fossify/phone/extensions/CallExt.kt
@@ -106,12 +106,11 @@ fun SimpleActivity.getHandleToUse(
         if (it) {
             val defaultHandle =
                 telecomManager.getDefaultOutgoingPhoneAccount(PhoneAccount.SCHEME_TEL)
+            // hasExtra() can be true with a null parcelable (e.g. locked SIM); extract safely and fall through.
+            val intentHandle = intent?.getParcelableExtra<PhoneAccountHandle>(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE)
             when {
                 forceSimSelector -> showSelectSimDialog(phoneNumber, callback)
-                intent?.hasExtra(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE) == true -> {
-                    callback(intent.getParcelableExtra(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE)!!)
-                }
-
+                intentHandle != null -> callback(intentHandle)
                 config.getCustomSIM(phoneNumber) != null -> {
                     callback(config.getCustomSIM(phoneNumber))
                 }


### PR DESCRIPTION
Intent.hasExtra(EXTRA_PHONE_ACCOUNT_HANDLE) only confirms the key is present, not that the parcelable resolves to a non-null value. When the handle points to a SIM slot that's present but inactive/locked, getParcelableExtra() can return null and the !! throws an NPE.

Extract the extra defensively and fall back to the existing options (saved custom SIM, default outgoing account, SIM selector dialog) instead of crashing.

#### Type of change(s)
- [X] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- `getHandleToUse()` used `intent.getParcelableExtra(EXTRA_PHONE_ACCOUNT_HANDLE)!!` after only checking `hasExtra()`, which doesn't guarantee the parcelable actually resolves to a non-null handle
- On a dual-SIM device where the second SIM slot is present but locked/inactive (PIN not entered), the handle fails to resolve, `getParcelableExtra()` returns null, and `!!` throws an NPE toast when tapping "Call back" on a missed-call notification
- Extract the extra into a nullable local and let it fall through the existing `when` fallbacks (saved custom SIM → default outgoing account → SIM selector dialog) instead of crashing

#### Tests performed
- Reproduced the crash on a Samsung Galaxy S24 (dual SIM, second SIM inactive/locked) and captured the stack trace confirming the failure at this exact line
- Applied the fix, rebuilt, and confirmed tapping "Call back" on a missed-call notification in the same conditions no longer crashes

#### Closes the following issue(s)
- Closes #134
- Closes #473

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [X] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [X] I understand every change in this pull request.