### PR TITLE
fix: include organizations in speed dial search

### DIFF
--- a/app/src/main/kotlin/org/fossify/phone/dialogs/SelectContactDialog.kt
+++ b/app/src/main/kotlin/org/fossify/phone/dialogs/SelectContactDialog.kt
@@ -12,6 +12,7 @@ import org.fossify.phone.R
 import org.fossify.phone.activities.SimpleActivity
 import org.fossify.phone.adapters.ContactsAdapter
 import org.fossify.phone.databinding.DialogSelectContactBinding
+import org.fossify.phone.extensions.matchesSearchQuery
 import org.fossify.phone.extensions.setupWithContacts
 
 class SelectContactDialog(val activity: SimpleActivity, val contacts: List<Contact>, val callback: (selectedContact: Contact) -> Unit) {
@@ -97,8 +98,10 @@ class SelectContactDialog(val activity: SimpleActivity, val contacts: List<Conta
     private fun filterContactListBySearchQuery(query: String) {
         val adapter = binding.selectContactList.adapter as? ContactsAdapter
         var contactsToShow = contacts
-        if (query.isNotEmpty()) {
-            contactsToShow = contacts.filter { it.name.contains(query, true) }
+        val fixedQuery = query.trim().replace("\\s+".toRegex(), " ")
+        if (fixedQuery.isNotEmpty()) {
+            val shouldNormalize = fixedQuery.normalizeString() == fixedQuery
+            contactsToShow = contacts.filter { it.matchesSearchQuery(fixedQuery, shouldNormalize) }
         }
         checkPlaceholderVisibility(contactsToShow)
 

--- a/app/src/main/kotlin/org/fossify/phone/extensions/Contact.kt
+++ b/app/src/main/kotlin/org/fossify/phone/extensions/Contact.kt
@@ -1,0 +1,17 @@
+package org.fossify.phone.extensions
+
+import org.fossify.commons.helpers.getProperText
+import org.fossify.commons.models.contacts.Contact
+
+fun Contact.matchesSearchQuery(query: String, shouldNormalize: Boolean): Boolean {
+    return getProperText(getNameToDisplay(), shouldNormalize).contains(query, true) ||
+        getProperText(nickname, shouldNormalize).contains(query, true) ||
+        (query.toLongOrNull() != null && doesContainPhoneNumber(query, true)) ||
+        emails.any { it.value.contains(query, true) } ||
+        addresses.any { getProperText(it.value, shouldNormalize).contains(query, true) } ||
+        IMs.any { it.value.contains(query, true) } ||
+        getProperText(notes, shouldNormalize).contains(query, true) ||
+        getProperText(organization.company, shouldNormalize).contains(query, true) ||
+        getProperText(organization.jobPosition, shouldNormalize).contains(query, true) ||
+        websites.any { it.contains(query, true) }
+}

--- a/app/src/main/kotlin/org/fossify/phone/fragments/ContactsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/phone/fragments/ContactsFragment.kt
@@ -28,6 +28,7 @@ import org.fossify.phone.databinding.FragmentContactsBinding
 import org.fossify.phone.databinding.FragmentLettersLayoutBinding
 import org.fossify.phone.extensions.handleGenericContactClick
 import org.fossify.phone.extensions.launchCreateNewContactIntent
+import org.fossify.phone.extensions.matchesSearchQuery
 import org.fossify.phone.extensions.setupWithContacts
 import org.fossify.phone.extensions.startContactDetailsIntent
 import org.fossify.phone.interfaces.RefreshItemsListener
@@ -159,18 +160,7 @@ class ContactsFragment(context: Context, attributeSet: AttributeSet) : MyViewPag
     override fun onSearchQueryChanged(text: String) {
         val fixedText = text.trim().replace("\\s+".toRegex(), " ")
         val shouldNormalize = fixedText.normalizeString() == fixedText
-        val filtered = allContacts.filter { contact ->
-            getProperText(contact.getNameToDisplay(), shouldNormalize).contains(fixedText, true) ||
-                getProperText(contact.nickname, shouldNormalize).contains(fixedText, true) ||
-                (fixedText.toLongOrNull() != null && contact.doesContainPhoneNumber(fixedText, true)) ||
-                contact.emails.any { it.value.contains(fixedText, true) } ||
-                contact.addresses.any { getProperText(it.value, shouldNormalize).contains(fixedText, true) } ||
-                contact.IMs.any { it.value.contains(fixedText, true) } ||
-                getProperText(contact.notes, shouldNormalize).contains(fixedText, true) ||
-                getProperText(contact.organization.company, shouldNormalize).contains(fixedText, true) ||
-                getProperText(contact.organization.jobPosition, shouldNormalize).contains(fixedText, true) ||
-                contact.websites.any { it.contains(fixedText, true) }
-        } as ArrayList
+        val filtered = allContacts.filter { it.matchesSearchQuery(fixedText, shouldNormalize) } as ArrayList
 
         filtered.sortBy {
             val nameToDisplay = it.getNameToDisplay()


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Reused the Contacts tab search predicate in the speed-dial contact picker
- Search live contact fields, including company and job position, instead of the cached display name
- Preserved normalized name and phone-number matching

#### Tests performed
- `./gradlew detekt`

#### Closes the following issue(s)
- Closes #689

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.
