### PR TITLE
feat: Add Flip to Mute option for incoming calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added Flip to Mute option (#65)
 
 ## [1.11.1] - 2026-02-01
 ### Changed

--- a/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
@@ -61,6 +61,7 @@ class SettingsActivity : SimpleActivity() {
     }
 
     private val binding by viewBinding(ActivitySettingsBinding::inflate)
+
     private val getContent =
         registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             if (uri != null) {
@@ -83,7 +84,6 @@ class SettingsActivity : SimpleActivity() {
         setContentView(binding.root)
         setupOptionsMenu()
         refreshMenuItems()
-
         binding.apply {
             setupEdgeToEdge(padBottomSystem = listOf(settingsNestedScrollview))
             setupMaterialScrollListener(binding.settingsNestedScrollview, binding.settingsAppbar)
@@ -93,7 +93,6 @@ class SettingsActivity : SimpleActivity() {
     override fun onResume() {
         super.onResume()
         setupTopAppBar(binding.settingsAppbar, NavigationIcon.Arrow)
-
         setupCustomizeColors()
         setupUseEnglish()
         setupLanguage()
@@ -115,10 +114,10 @@ class SettingsActivity : SimpleActivity() {
         setupDisableProximitySensor()
         setupDisableSwipeToAnswer()
         setupAlwaysShowFullscreen()
+        setupFlipToMute()
         setupCallsExport()
         setupCallsImport()
         updateTextColors(binding.settingsHolder)
-
         binding.apply {
             arrayOf(
                 settingsColorCustomizationSectionLabel,
@@ -171,7 +170,6 @@ class SettingsActivity : SimpleActivity() {
             }
         }
     }
-
     private fun setupLanguage() {
         binding.apply {
             settingsLanguage.text = Locale.getDefault().displayLanguage
@@ -221,7 +219,6 @@ class SettingsActivity : SimpleActivity() {
                 RadioItem(FONT_SIZE_LARGE, getString(R.string.large)),
                 RadioItem(FONT_SIZE_EXTRA_LARGE, getString(R.string.extra_large))
             )
-
             RadioGroupDialog(this@SettingsActivity, items, config.fontSize) {
                 config.fontSize = it as Int
                 binding.settingsFontSize.text = getFontSizeText()
@@ -244,7 +241,6 @@ class SettingsActivity : SimpleActivity() {
                 RadioItem(TAB_CALL_HISTORY, getString(R.string.call_history_tab)),
                 RadioItem(TAB_LAST_USED, getString(R.string.last_used_tab))
             )
-
             RadioGroupDialog(this@SettingsActivity, items, config.defaultTab) {
                 config.defaultTab = it as Int
                 binding.settingsDefaultTab.text = getDefaultTabText()
@@ -268,7 +264,6 @@ class SettingsActivity : SimpleActivity() {
                 RadioItem(ON_CLICK_CALL_CONTACT, getString(org.fossify.commons.R.string.call_contact)),
                 RadioItem(ON_CLICK_VIEW_CONTACT, getString(org.fossify.commons.R.string.view_contact))
             )
-
             RadioGroupDialog(this@SettingsActivity, items, config.onContactClick) {
                 config.onContactClick = it as Int
                 binding.settingsOnContactClick.text = getOnContactClickText()
@@ -391,6 +386,16 @@ class SettingsActivity : SimpleActivity() {
         }
     }
 
+    private fun setupFlipToMute() {
+        binding.apply {
+            settingsFlipToMute.isChecked = config.flipToMute
+            settingsFlipToMuteHolder.setOnClickListener {
+                settingsFlipToMute.toggle()
+                config.flipToMute = settingsFlipToMute.isChecked
+            }
+        }
+    }
+
     private fun setupCallsExport() {
         binding.settingsExportCallsHolder.setOnClickListener {
             ExportCallHistoryDialog(this) { filename ->
@@ -410,14 +415,11 @@ class SettingsActivity : SimpleActivity() {
             val jsonString = contentResolver.openInputStream(uri)!!.use { inputStream ->
                 inputStream.bufferedReader().readText()
             }
-
             val objects = Json.decodeFromString<List<RecentCall>>(jsonString)
-
             if (objects.isEmpty()) {
                 toast(R.string.no_entries_for_importing)
                 return
             }
-
             RecentsHelper(this).restoreRecentCalls(this, objects) {
                 toast(R.string.importing_successful)
             }
@@ -436,7 +438,6 @@ class SettingsActivity : SimpleActivity() {
         } else {
             try {
                 val outputStream = contentResolver.openOutputStream(uri)!!
-
                 val jsonString = Json.encodeToString(recents)
                 outputStream.use {
                     it.write(jsonString.toByteArray())

--- a/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/phone/activities/SettingsActivity.kt
@@ -1,11 +1,13 @@
 package org.fossify.phone.activities
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import androidx.activity.result.contract.ActivityResultContracts
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.fossify.commons.activities.ManageBlockedNumbersActivity
 import org.fossify.commons.dialogs.ChangeDateTimeFormatDialog
@@ -170,6 +172,8 @@ class SettingsActivity : SimpleActivity() {
             }
         }
     }
+
+    @SuppressLint("NewApi")
     private fun setupLanguage() {
         binding.apply {
             settingsLanguage.text = Locale.getDefault().displayLanguage

--- a/app/src/main/kotlin/org/fossify/phone/helpers/CallManager.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/CallManager.kt
@@ -17,6 +17,7 @@ class CallManager {
     companion object {
         @SuppressLint("StaticFieldLeak")
         var inCallService: InCallService? = null
+
         private var call: Call? = null
         private val calls = mutableListOf<Call>()
         private val listeners = CopyOnWriteArraySet<CallManagerListener>()
@@ -27,6 +28,7 @@ class CallManager {
             for (listener in listeners) {
                 listener.onPrimaryCallChanged(call)
             }
+
             call.registerCallback(object : Call.Callback() {
                 override fun onStateChanged(call: Call, state: Int) {
                     updateState()
@@ -62,6 +64,7 @@ class CallManager {
                     val active = calls.find { it.getStateCompat() == Call.STATE_ACTIVE }
                     val newCall = calls.find { it.getStateCompat() == Call.STATE_CONNECTING || it.getStateCompat() == Call.STATE_DIALING }
                     val onHold = calls.find { it.getStateCompat() == Call.STATE_HOLDING }
+
                     if (active != null && newCall != null) {
                         TwoCalls(newCall, active)
                     } else if (newCall != null && onHold != null) {
@@ -82,6 +85,7 @@ class CallManager {
                     } else {
                         null
                     }
+
                     if (secondCall == null) {
                         SingleCall(conference)
                     } else {
@@ -121,6 +125,7 @@ class CallManager {
                 is SingleCall -> phoneState.call
                 is TwoCalls -> phoneState.active
             }
+
             var notify = true
             if (primaryCall == null) {
                 call = null
@@ -131,6 +136,7 @@ class CallManager {
                 }
                 notify = false
             }
+
             if (notify) {
                 for (listener in listeners) {
                     listener.onStateChanged()
@@ -203,9 +209,7 @@ class CallManager {
 
         fun keypad(char: Char) {
             call?.playDtmfTone(char)
-            Handler().postDelayed({
-                call?.stopDtmfTone()
-            }, DIALPAD_TONE_LENGTH_MS)
+            Handler().postDelayed({ call?.stopDtmfTone() }, DIALPAD_TONE_LENGTH_MS)
         }
     }
 }

--- a/app/src/main/kotlin/org/fossify/phone/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/Config.kt
@@ -17,6 +17,7 @@ import java.util.Locale
 class Config(context: Context) : BaseConfig(context) {
     companion object {
         fun newInstance(context: Context) = Config(context)
+        private const val FLIP_TO_MUTE = "flip_to_mute"
     }
 
     private val regionHint: String by lazy {
@@ -54,6 +55,7 @@ class Config(context: Context) : BaseConfig(context) {
 
     fun getCustomSIM(number: String): PhoneAccountHandle? {
         val key = getKeyForCustomSIM(number)
+
         prefs.getPhoneAccountHandleModel(key, null)?.let {
             return it.toPhoneAccountHandle()
         }
@@ -78,7 +80,6 @@ class Config(context: Context) : BaseConfig(context) {
                     handle
                 }
             }
-
         return migratedHandle
     }
 
@@ -135,4 +136,8 @@ class Config(context: Context) : BaseConfig(context) {
     var alwaysShowFullscreen: Boolean
         get() = prefs.getBoolean(ALWAYS_SHOW_FULLSCREEN, false)
         set(alwaysShowFullscreen) = prefs.edit().putBoolean(ALWAYS_SHOW_FULLSCREEN, alwaysShowFullscreen).apply()
+
+    var flipToMute: Boolean
+        get() = prefs.getBoolean(FLIP_TO_MUTE, false)
+        set(flipToMute) = prefs.edit().putBoolean(FLIP_TO_MUTE, flipToMute).apply()
 }

--- a/app/src/main/kotlin/org/fossify/phone/helpers/FlipToMuteHelper.kt
+++ b/app/src/main/kotlin/org/fossify/phone/helpers/FlipToMuteHelper.kt
@@ -1,0 +1,62 @@
+package org.fossify.phone.helpers
+
+import android.Manifest
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.telecom.TelecomManager
+import androidx.annotation.RequiresPermission
+
+class FlipToMuteHelper(private val context: Context) {
+    private var sensorManager: SensorManager? = null
+    private var accelerometer: Sensor? = null
+    private var isListening = false
+    private var hasBeenFaceUp = false // Mémorise si le téléphone a d'abord été à l'endroit
+
+    private val sensorListener = object : SensorEventListener {
+        @RequiresPermission(Manifest.permission.MODIFY_PHONE_STATE)
+        override fun onSensorChanged(event: SensorEvent?) {
+            if (event?.sensor?.type == Sensor.TYPE_ACCELEROMETER) {
+                val z = event.values[2]
+
+                // Si le téléphone est levé ou face vers le haut, on le mémorise
+                if (z > 3.0f) {
+                    hasBeenFaceUp = true
+                }
+
+                // S'il est retourné face vers le bas ET qu'il a été vu à l'endroit avant
+                if (z < -8.0f && hasBeenFaceUp) {
+                    muteRinger()
+                    stopListening()
+                }
+            }
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+    }
+
+    fun startListening() {
+        if (isListening) return
+        hasBeenFaceUp = false // On réinitialise l'état pour chaque nouvel appel
+        sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        accelerometer = sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        accelerometer?.let {
+            sensorManager?.registerListener(sensorListener, it, SensorManager.SENSOR_DELAY_NORMAL)
+            isListening = true
+        }
+    }
+
+    fun stopListening() {
+        if (!isListening) return
+        sensorManager?.unregisterListener(sensorListener)
+        isListening = false
+    }
+
+    @RequiresPermission(Manifest.permission.MODIFY_PHONE_STATE)
+    private fun muteRinger() {
+        val telecomManager = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+        telecomManager.silenceRinger()
+    }
+}

--- a/app/src/main/kotlin/org/fossify/phone/services/CallService.kt
+++ b/app/src/main/kotlin/org/fossify/phone/services/CallService.kt
@@ -13,16 +13,28 @@ import org.fossify.phone.extensions.keyguardManager
 import org.fossify.phone.extensions.powerManager
 import org.fossify.phone.helpers.CallManager
 import org.fossify.phone.helpers.CallNotificationManager
+import org.fossify.phone.helpers.FlipToMuteHelper
 import org.fossify.phone.helpers.NoCall
 import org.fossify.phone.models.Events
 import org.greenrobot.eventbus.EventBus
 
 class CallService : InCallService() {
+    private lateinit var flipToMuteHelper: FlipToMuteHelper
+
+    override fun onCreate() {
+        super.onCreate()
+        flipToMuteHelper = FlipToMuteHelper(this)
+    }
+
     private val callNotificationManager by lazy { CallNotificationManager(this) }
 
     private val callListener = object : Call.Callback() {
         override fun onStateChanged(call: Call, state: Int) {
             super.onStateChanged(call, state)
+            if (state != Call.STATE_RINGING) {
+                flipToMuteHelper.stopListening()
+            }
+
             if (state == Call.STATE_DISCONNECTED || state == Call.STATE_DISCONNECTING) {
                 callNotificationManager.cancelNotification()
             } else {
@@ -37,6 +49,10 @@ class CallService : InCallService() {
         CallManager.inCallService = this
         call.registerCallback(callListener)
 
+        if (call.state == Call.STATE_RINGING && config.flipToMute) {
+            flipToMuteHelper.startListening()
+        }
+
         // Incoming/Outgoing (locked): high priority (FSI)
         // Incoming (unlocked): if user opted in, low priority ➜ manual activity start, otherwise high priority (FSI)
         // Outgoing (unlocked): low priority ➜ manual activity start
@@ -50,6 +66,7 @@ class CallService : InCallService() {
         }
 
         callNotificationManager.setupNotification(lowPriority)
+
         if (
             lowPriority
             || !hasPermission(PERMISSION_POST_NOTIFICATIONS)
@@ -67,9 +84,11 @@ class CallService : InCallService() {
 
     override fun onCallRemoved(call: Call) {
         super.onCallRemoved(call)
+        flipToMuteHelper.stopListening()
         call.unregisterCallback(callListener)
         val wasPrimaryCall = call == CallManager.getPrimaryCall()
         CallManager.onCallRemoved(call)
+
         if (CallManager.getPhoneState() == NoCall) {
             CallManager.inCallService = null
             callNotificationManager.cancelNotification()
@@ -92,6 +111,7 @@ class CallService : InCallService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        flipToMuteHelper.stopListening()
         callNotificationManager.cancelNotification()
     }
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -360,14 +360,25 @@
                 style="@style/SettingsHolderSwitchStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
-
                 <org.fossify.commons.views.MyMaterialSwitch
                     android:id="@+id/settings_always_show_fullscreen"
                     style="@style/SettingsSwitchStyle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/show_incoming_calls_full_screen" />
+            </RelativeLayout>
 
+            <RelativeLayout
+                android:id="@+id/settings_flip_to_mute_holder"
+                style="@style/SettingsHolderSwitchStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <org.fossify.commons.views.MyMaterialSwitch
+                    android:id="@+id/settings_flip_to_mute"
+                    style="@style/SettingsSwitchStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/flip_to_mute_title" />
             </RelativeLayout>
 
             <include

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <string name="export_call_history">Export call history</string>
     <string name="import_call_history">Import call history</string>
     <string name="calling_accounts">Calling accounts</string>
+    <string name="flip_to_mute_title">Flip to mute</string>
+    <string name="flip_to_mute_description">Silence the ringer by turning the phone face down during an incoming call</string>
 
     <!-- FAQ -->
     <string name="faq_1_title">I hear incoming calls, but the screen doesn\'t turn on. What can I do?</string>


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [X] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Added `FlipToMuteHelper.kt` using `SensorEventListener` to monitor accelerometer data during incoming calls.
- Mutes the ringer (`telecomManager.silenceRinger()`) when the device is turned face down (`z < -8.0` after initial face-up detection).
- Integrated sensor lifecycle into `CallService.kt` during `STATE_RINGING`.
- Added a toggle switch in `SettingsActivity` ("Flip to mute") with associated strings and config persistence.

#### Tests performed
- Manually tested on a Samsung Galaxy S10 (crDroid 12.x / Android 16 -  debug build) and a Google Pixel 8 (GrapheneOS / Android 17 - release build) with incoming calls.

#### Before & after preview
<p align="center">
  <img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/ff231c45-ff9d-4849-ab36-b6f5eb4f052a" width=189 />
  <img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/28eb68c8-a71e-4872-a395-ca6e187ddd78" width=180 />
</p>

#### Closes the following issue(s)
- Closes #65

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [X] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [X] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
